### PR TITLE
feat(auth):persist user/roles with JPA + Flyway schema and seed

### DIFF
--- a/src/main/java/com/alemandan/crm/config/DataInitializer.java
+++ b/src/main/java/com/alemandan/crm/config/DataInitializer.java
@@ -1,0 +1,42 @@
+package com.alemandan.crm.config;
+
+import com.alemandan.crm.model.AppRole;
+import com.alemandan.crm.model.AppUser;
+import com.alemandan.crm.repository.AppRoleRepository;
+import com.alemandan.crm.repository.AppUserRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Configuration
+public class DataInitializer {
+
+    @Bean
+    @Transactional
+    CommandLineRunner initData(AppRoleRepository roleRepo,
+                               AppUserRepository userRepo,
+                               PasswordEncoder encoder) {
+        return args -> {
+            // Roles
+            AppRole adminRole = roleRepo.findByName("ADMIN").orElseGet(() -> roleRepo.save(new AppRole("ADMIN")));
+            AppRole employeeRole = roleRepo.findByName("EMPLOYEE").orElseGet(() -> roleRepo.save(new AppRole("EMPLOYEE")));
+
+            // Usuarios (solo si no existen)
+            if (!userRepo.existsByUsername("admin")) {
+                AppUser admin = new AppUser("admin", encoder.encode("admin123"), true);
+                admin.setRoles(Set.of(adminRole, employeeRole));
+                userRepo.save(admin);
+            }
+
+            if (!userRepo.existsByUsername("empleado")) {
+                AppUser empleado = new AppUser("empleado", encoder.encode("empleado123"), true);
+                empleado.setRoles(Set.of(employeeRole));
+                userRepo.save(empleado);
+            }
+        };
+    }
+}

--- a/src/main/java/com/alemandan/crm/model/AppRole.java
+++ b/src/main/java/com/alemandan/crm/model/AppRole.java
@@ -1,0 +1,27 @@
+package com.alemandan.crm.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "roles")
+public class AppRole {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String name;
+
+    public AppRole() {}
+
+    public AppRole(String name) {
+        this.name = name;
+    }
+
+    public Long getId() { return id; }
+    public String getName() { return name; }
+
+    public void setId(Long id) { this.id = id; }
+    public void setName(String name) { this.name = name; }
+}

--- a/src/main/java/com/alemandan/crm/model/AppUser.java
+++ b/src/main/java/com/alemandan/crm/model/AppUser.java
@@ -1,0 +1,51 @@
+package com.alemandan.crm.model;
+
+import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class AppUser {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false, length = 100)
+    private String password;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "users_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<AppRole> roles = new HashSet<>();
+
+    public AppUser() {}
+
+    public AppUser(String username, String password, boolean enabled) {
+        this.username = username;
+        this.password = password;
+        this.enabled = enabled;
+    }
+
+    public Long getId() { return id; }
+    public String getUsername() { return username; }
+    public String getPassword() { return password; }
+    public boolean isEnabled() { return enabled; }
+    public Set<AppRole> getRoles() { return roles; }
+
+    public void setId(Long id) { this.id = id; }
+    public void setUsername(String username) { this.username = username; }
+    public void setPassword(String password) { this.password = password; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public void setRoles(Set<AppRole> roles) { this.roles = roles; }
+}

--- a/src/main/java/com/alemandan/crm/repository/AppRoleRepository.java
+++ b/src/main/java/com/alemandan/crm/repository/AppRoleRepository.java
@@ -1,0 +1,11 @@
+package com.alemandan.crm.repository;
+
+import com.alemandan.crm.model.AppRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AppRoleRepository extends JpaRepository<AppRole, Long> {
+    Optional<AppRole> findByName(String name);
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/alemandan/crm/repository/AppUserRepository.java
+++ b/src/main/java/com/alemandan/crm/repository/AppUserRepository.java
@@ -1,0 +1,11 @@
+package com.alemandan.crm.repository;
+
+import com.alemandan.crm.model.AppUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AppUserRepository extends JpaRepository<AppUser, Long> {
+    Optional<AppUser> findByUsername(String username);
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/alemandan/crm/security/CustomUserDetailsService.java
+++ b/src/main/java/com/alemandan/crm/security/CustomUserDetailsService.java
@@ -1,0 +1,42 @@
+package com.alemandan.crm.security;
+
+import com.alemandan.crm.model.AppUser;
+import com.alemandan.crm.repository.AppUserRepository;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final AppUserRepository userRepository;
+
+    public CustomUserDetailsService(AppUserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        AppUser user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado: " + username));
+
+        Set<GrantedAuthority> authorities = user.getRoles().stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.getName()))
+                .collect(Collectors.toSet());
+
+        return new User(
+                user.getUsername(),
+                user.getPassword(),
+                user.isEnabled(),
+                true, true, true,
+                authorities
+        );
+    }
+}

--- a/src/main/java/com/alemandan/crm/security/SecurityConfig.java
+++ b/src/main/java/com/alemandan/crm/security/SecurityConfig.java
@@ -3,12 +3,8 @@ package com.alemandan.crm.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -17,22 +13,6 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
-    }
-
-    // Usuarios en memoria solo para desarrollo/pruebas
-    @Bean
-    public UserDetailsService userDetailsService(PasswordEncoder encoder) {
-        UserDetails admin = User.withUsername("admin")
-                .password(encoder.encode("admin123"))
-                .roles("ADMIN")
-                .build();
-
-        UserDetails empleado = User.withUsername("empleado")
-                .password(encoder.encode("empleado123"))
-                .roles("EMPLOYEE")
-                .build();
-
-        return new InMemoryUserDetailsManager(admin, empleado);
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,13 +7,15 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+
   h2:
     console:
       enabled: true
       path: /h2
+
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
@@ -21,7 +23,8 @@ spring:
     open-in-view: false
 
   flyway:
-    enabled: false
+    enabled: true
+    locations: classpath:db/migration
 
 server:
   port: 8080

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,23 @@
+-- Esquema base para usuarios y roles
+
+CREATE TABLE roles (
+                       id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                       name VARCHAR(50) NOT NULL UNIQUE
+);
+
+CREATE TABLE users (
+                       id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                       username VARCHAR(50) NOT NULL UNIQUE,
+                       password VARCHAR(100) NOT NULL,
+                       enabled BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE users_roles (
+                             user_id BIGINT NOT NULL,
+                             role_id BIGINT NOT NULL,
+                             PRIMARY KEY (user_id, role_id),
+                             CONSTRAINT fk_users_roles_user
+                                 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+                             CONSTRAINT fk_users_roles_role
+                                 FOREIGN KEY (role_id) REFERENCES roles (id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
Persistencia de usuarios y roles con JPA y autenticación basada en base de datos. Se agrega esquema inicial con Flyway y datos seed con contraseñas encriptadas (BCrypt).

## Changes
- Flyway: V1__init.sql para tablas `users`, `roles` y `users_roles`.
- Entidades JPA: `AppUser`, `AppRole`.
- Repositorios: `AppUserRepository`, `AppRoleRepository`.
- `CustomUserDetailsService` para cargar usuarios desde DB.
- `DataInitializer` para seed de roles y usuarios (`admin`, `empleado`).
- `SecurityConfig` actualizado a autenticación por DB (se elimina in-memory).

## Database
- Migración: `src/main/resources/db/migration/V1__init.sql`
- Usuarios iniciales:
  - admin / admin123 (roles: ADMIN, EMPLOYEE)
  - empleado / empleado123 (roles: EMPLOYEE)

## How to test
1. mvn clean spring-boot:run
2. Verifica que Flyway aplique V1 y que el initializer cree datos.
3. Ir a http://localhost:8080 → “Ir al panel” → /login
4. Iniciar sesión con admin o empleado.
5. Comprobar que /admin/** queda restringido a ROLE_ADMIN.

## Notes
- H2 console en http://localhost:8080/h2 (JDBC URL: jdbc:h2:mem:alemandan, user: sa).
- Passwords almacenadas con BCrypt.