### PR TITLE
chore(db): add PostgreSQL profile + Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  db:
+    image: postgres:16
+    container_name: alemandan-postgres
+    environment:
+      POSTGRES_DB: alemandan
+      POSTGRES_USER: alemandan
+      POSTGRES_PASSWORD: alemandan
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U alemandan -d alemandan"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,13 @@
             <artifactId>flyway-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <!-- Si Spring Boot no te gestiona la versión automáticamente, usa la misma que trae Boot -->
+            <version>${flyway.version}</version>
+        </dependency>
+
         <!-- Thymeleaf extras para etiquetas de seguridad -->
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>
@@ -109,6 +116,13 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Dependency postgreSQL -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/application-postgres.yml
+++ b/src/main/resources/application-postgres.yml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/alemandan
+    username: alemandan
+    password: alemandan
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    open-in-view: false
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+server:
+  port: 8080
+
+logging:
+  level:
+    org.hibernate.SQL: INFO


### PR DESCRIPTION
## Summary
Configura PostgreSQL para desarrollo local con Docker Compose y un perfil `postgres`. Flyway migra el esquema y el initializer crea usuarios/roles.

## Changes
- docker-compose.yml con Postgres 16.
- Perfil `application-postgres.yml` (Hibernate dialect + Flyway).
- Dependencia `org.postgresql:postgresql` en pom.xml.

## How to test
1. docker compose up -d
2. mvn clean spring-boot:run -Dspring-boot.run.profiles=postgres
3. Login en http://localhost:8080 con:
   - admin / admin123
   - empleado / empleado123